### PR TITLE
Normalize country input

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'faker'
 gem 'haml'
 gem 'factory_girl'
 
+gem 'normalize_country'
+
 group :test do
   gem 'shoulda-matchers'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     multi_xml (0.5.5)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    normalize_country (0.2.1)
     pg (0.19.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -111,6 +112,7 @@ DEPENDENCIES
   faker
   haml
   httparty
+  normalize_country
   pg
   pry
   rack-test

--- a/app/services/lastfm_service.rb
+++ b/app/services/lastfm_service.rb
@@ -24,6 +24,8 @@ module LastFmService
   # end
 
   def self.top_tracks(country)
+    country = NormalizeCountry(country)
+
     url = "http://ws.audioscrobbler.com/2.0/?method=geo.gettoptracks&country=#{country}&limit=10&api_key=#{KEY}"
 
     response = HTTParty.get(url)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -27,6 +27,8 @@ require 'erb'
 require 'faker'
 require 'pry'
 
+require 'normalize_country'
+
 # Some helper constants for path-centric logic
 APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 


### PR DESCRIPTION
Use 'normalize_country' gem to normalize user input. This allows user to type in countries names like 'south korea', 'usa', and etc. You may want to test it first 😄 
#39 