### PR TITLE
User string as keys for Httparty headers

### DIFF
--- a/app/services/ranking_service.rb
+++ b/app/services/ranking_service.rb
@@ -29,7 +29,7 @@ module RankingService
   # }}
   def self.top_tracks_from_melon
     url = "http://apis.skplanetx.com/melon/charts/realtime?version=1&page=1&count=10"
-    headers = { "appKey": MELON_KEY, "Accept": "application/json" }
+    headers = { "appKey" => MELON_KEY, "Accept" => "application/json" }
     response = HTTParty.get(url, headers: headers).parsed_response
     track_list = response["melon"]["songs"]["song"]
     track_list.map do |track|


### PR DESCRIPTION
Httparty header hash expects the keys to be String instead of Symbol. I missed this on my local machine most likely because of Ruby version issue. Hopefully this will solve the problem.